### PR TITLE
Add function  basic authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production? # 本番環境のみBasic認証を行う
+
+  private
+
+  # 本番環境ならtrueを返すメソッド
+  def production?
+    Rails.env.production?
+  end
+
+  # Basic認証のメソッドを定義、実際のユーザー名とパスワードは環境変数に記載
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+
 end

--- a/app/controllers/exam_controller.rb
+++ b/app/controllers/exam_controller.rb
@@ -1,0 +1,4 @@
+class ExamController < ApplicationController
+  def index
+  end
+end

--- a/app/views/exam/index.html.erb
+++ b/app/views/exam/index.html.erb
@@ -1,0 +1,1 @@
+hallow world!

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,6 +25,14 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
+# 環境変数を明示的に指定
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
+}
+
 # デプロイ処理が終わった後、Unicornを再起動するための記述
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -61,3 +61,7 @@
 #   }
 
 server "18.179.163.60", user: "ec2-user", roles: %w{app db web}
+
+# unicornに現在の環境を本番環境だと認識させる
+set :rails_env, "production"
+set :unicorn_rack_env, "production"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root "exam#index"
 end


### PR DESCRIPTION
## What
- Basic認証の機能を追加
- 本番環境のみで作動するよう設定してある

## Why
- メルカリの模倣をデプロイするので、一般ユーザーが簡単には入れないようにする

## 注意点
- テストの為だけにexamコントローラーを作成している
- その他機能の実装が始まったらexamコントローラーは削除する