### PR TITLE
made "add credit card page"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "items/new";
 @import "profiles/index";
 @import "items/create";
+@import "credit_cards/index";

--- a/app/assets/stylesheets/credit_cards/index.scss
+++ b/app/assets/stylesheets/credit_cards/index.scss
@@ -1,0 +1,48 @@
+.credit_cards-wrapper{
+  width: 100vw;
+  height: 100vh;
+  background-color: $back-gray;
+  &__contents{
+    width: 1020px;
+    margin: 0 auto 0;
+    margin-top: 40px;
+    display: flex;
+    &__left{
+      width: 280px;
+      height: 500px;
+      background-color: white;
+      margin: 0 40px 0 0;
+    }
+    &__right{
+      width: 700px;
+      height:500px;
+      background-color: white;
+      text-align: center;
+
+      &__title{
+          font-size: 24px;
+          font-weight: 600;
+          padding: 8px 24px;
+      }
+      &__heading{
+        font-size: 15px;
+        font-weight: 500;
+        color: $black;
+        padding: 40px;
+      }
+      &__btn{
+        .credit_cards-btn{
+          text-decoration: none;
+          width: 250px;
+          height: 50px;
+          background-color: #ea352c;
+          color: white;
+          font-size: 15px;
+          margin: 0 auto 0;
+          display: block;
+          line-height: 50px;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,0 +1,2 @@
+class CreditCardsController < ApplicationController
+end

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,2 +1,7 @@
 class CreditCardsController < ApplicationController
+  def index
+  end
+
+  def create
+  end
 end

--- a/app/views/credit_cards/index.html.haml
+++ b/app/views/credit_cards/index.html.haml
@@ -1,0 +1,21 @@
+-# 2-4.ユーザークレジットカード登録ページ
+-# ①ヘッダー、②コンテンツ（②-1左カラム、②-2右カラム）、③フッターの大きく4要素でできている。
+.credit_cards-wrapper
+  -# ①ヘッダー
+  = render 'layouts/header'
+  -# ②コンテンツ
+  .credit_cards-wrapper__contents
+    -# ②-1左カラム（キッドさん作成中）
+    .credit_cards-wrapper__contents__left
+    -# ②-2右カラム
+    .credit_cards-wrapper__contents__right
+      .credit_cards-wrapper__contents__right__title
+      %h2{ class: "credit_cards-heading" } 支払い方法
+      .credit_cards-wrapper__contents__right__heading
+        クレジットカード一覧
+      .credit_cards-wrapper__contents__right__btn
+        = link_to credit_cards_path, class: "credit_cards-btn" do
+          クレジットカードを追加する
+      
+  -# ③フッター
+  = render 'layouts/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   root "exam#index"
   resources :items, only: [:new, :create]
   resources :profiles,only: [:edit,:index]
+  resources :credit_cards,only: [:index, :create]
 end


### PR DESCRIPTION
## what
・ユーザーがマイページからクレジットカードを追加するためのページ
・マイページ＞支払い方法＞まだクレカを登録していないユーザーに表示されるページ

## why
商品購入のためにクレジットカードの登録が必要なため

## その他
・左側メニュー部分（.credit_cards-wrapper__contents__left）はメンバーの作成待ちです。  

<img width="1440" alt="スクリーンショット 2019-12-30 17 16 37" src="https://user-images.githubusercontent.com/30643581/71573620-2fde3780-2b28-11ea-8022-2fb10b61cf77.png">
