### PR TITLE
[wip]User management min edit

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,10 +11,23 @@ class User < ApplicationRecord
          validates :kana_mei, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/}
          # カタカナのみ許容する
          validates :birth_date, presence: true
-         validates :postal_code, presence: true
+         validates :postal_code, presence: true, format: {with: /\A[0-9]{3}[0-9]{4}\z/}
+         # 7桁の半角数字のみ許容（ハイフンなし）
          validates :prefectures, presence: true
          validates :city, presence: true
          validates :address, presence: true
          validates :tel, presence: true
+  
+  # 都道府県をプルダウンで実装するための文字列指定 [表示:DBに入る値]
+  enum prefectures: {
+    北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+    茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+    新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+    岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+    滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+    鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+    徳島県:36,香川県:37,愛媛県:38,高知県:39,
+    福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47
+  }
 
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -31,7 +31,8 @@
       .field
         = f.label :prefectures
         %br/
-        = f.text_field :prefectures, autofocus: true, autocomplete: "prefectures"
+        = f.select :prefectures, User.prefectures.keys, autofocus: true, autocomplete: "prefectures", prompt: '選択してください', class: 'xxxx'
+        -# calssはビュー合わせ
       .field
         = f.label :city
         %br/

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -6,9 +6,7 @@ ja:
         name_mei: お名前（名）
         kana_sei: お名前（セイ）
         kana_mei: お名前（メイ）
-        birthday_yyyy: 年
-        birthday_mm: 月
-        birthday_dd: 日
+        birth_date: 生年月日
         postal_code: 郵便番号
         prefectures: 都道府県
         city: 市区町村

--- a/db/migrate/20200103171045_change_data_prefectures_to_users.rb
+++ b/db/migrate/20200103171045_change_data_prefectures_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataPrefecturesToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :prefectures, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_03_093659) do
+ActiveRecord::Schema.define(version: 2020_01_03_171045) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "image", null: false
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2020_01_03_093659) do
     t.string "kana_mei", default: "", null: false
     t.date "birth_date", null: false
     t.string "postal_code", default: "", null: false
-    t.string "prefectures", default: "", null: false
+    t.integer "prefectures", default: 0, null: false
     t.string "city", default: "", null: false
     t.string "address", default: "", null: false
     t.string "building", default: ""


### PR DESCRIPTION
# what
- labelを日本語対応忘れ対応
- 都道府県をプルダウンで選択できるように修正、それに伴うカラムのデータ型変更

# why
- labelを日本語対応忘れ対応
> 日本語対応で対応漏れあったため対応

- 都道府県をプルダウンで選択できるように修正、それに伴うカラムのデータ型変更
> タイピングする手間を省きスムーズに登録ができ、不正な数値の入力を防ぐことができる。
