### PR TITLE
[wip]add bacground-color

### DIFF
--- a/app/assets/stylesheets/logout/_logout.scss
+++ b/app/assets/stylesheets/logout/_logout.scss
@@ -1,20 +1,23 @@
 .wrapper{
   .main-container{
     &__right{
-      & form{
-        padding: 64px;
-        .single-content{
-          max-width: 320px;
-          margin: 0 auto;
-          & button{
-            background-color:$corporate-red;
-            color:$white;
-            width:320px;
-            height:50px;
-            font-size: 14px;
-            cursor: pointer;
-          }
-        }  
+      .logout_wrapper{
+        background: $white;
+        & form{
+          padding: 64px;
+          .single-content{
+            max-width: 320px;
+            margin: 0 auto;
+            & button{
+              background-color:$corporate-red;
+              color:$white;
+              width:320px;
+              height:50px;
+              font-size: 14px;
+              cursor: pointer;
+            }
+          }  
+        }
       }
     }
   }

--- a/app/views/logout/index.html.haml
+++ b/app/views/logout/index.html.haml
@@ -6,7 +6,8 @@
     %main.main-container
       = render 'mypages/left'
       .main-container__right
-        %form
-          .single-content
-            %button.btn-red{type:"submit"} ログアウト       
+        .logout_wrapper
+          %form
+            .single-content
+              %button.btn-red{type:"submit"} ログアウト       
   = render 'layouts/footer'


### PR DESCRIPTION
# what
- ログアウトページの背景色が消えてしまう問題を修正

# why
- ログアウトページの背景色が消えてしまう問題を修正
> ログアウトページの背景色が[.main-container__right]に適用されていたのですが、他のページでも[.main-container__right]に色がつけられてしまい、バッティング状態でした。なので、その下に「.logout_wrapper」を作成しました。

[![Screenshot from Gyazo](https://gyazo.com/2a256aaeaefded4ed64cbcd3c0c2def1/raw)](https://gyazo.com/2a256aaeaefded4ed64cbcd3c0c2def1)