### PR TITLE
Edit item function  Server side

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,13 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+  end
+
   private
   def item_params
     params.require(:item)

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -1,0 +1,29 @@
+-# form 商品名、商品説明
+.exhibit-form
+  .exhibit-form__group
+    .exhibit-form__group__label
+      %label{ class: "exhibit-form-label" } 商品名
+      %span{ class: "exhibit-form-require"} 必須
+    .exhibit-form__group__input
+      = f.text_field :name, placeholder: "商品名（必須 40文字まで）", class: "textfield-default"
+  .exhibit-form__group--2
+    .exhibit-form__group__label
+      %label{ class: "exhibit-form-label" } 商品の説明
+      %span{ class: "exhibit-form-require"} 必須
+    .exhibit-form__group__input
+      = f.text_area :description, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class: "textarea-default"
+-# form 販売価格
+.exhibit-form
+  .exhibit-form__group2
+    .exhibit-form__group2__left
+      %label{ class: "exhibit-form-label-gray" } 販売価格
+      %label{ class: "exhibit-form-label-gray-small" } (300~9,999,999)
+    .exhibit-form__group2__right
+      .exhibit-form__group2__right__box#exhibit-form-price
+        .exhibit-form__group2__right__box__left
+          .exhibit-form__group2__right__box__left__box
+            %label{ class: "exhibit-form-label" } 価格
+            %span{ class: "exhibit-form-require"} 必須
+        .exhibit-form__group2__right__box__right
+          %label{ class: "exhibit-form-label-small" } ¥
+          = f.text_field :price, placeholder: "例）300", class: "textfield-small"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,38 @@
+-# 商品情報編集ページ
+-# ①ヘッダー、②コンテンツ、③フッター、の大きく3要素でできている
+.exhibit-wrapper
+
+  -# ①ヘッダー
+  = render 'items/layouts/exhibit_header'
+
+  -# ②コンテンツ（formがメインになっている）
+  .exhibit-wrapper__contents
+    .exhibit-page-description
+      商品の情報を入力
+    -# ここからform
+    = form_with(model: @item, local: true, id: "exhibit-form") do |f|
+      -# form 画像アップロード
+      .exhibit-form
+        .exhibit-form__group
+          .exhibit-form__group__label
+            %label{ class: "exhibit-form-label" } 出品画像
+            %span{ class: "exhibit-form-require"} 必須
+          .exhibit-form__group__label-small
+            %label{ class: "exhibit-form-label-small" } 最大10枚までアップロードできます。
+          .exhibit-form__group__image#exhibit-form-image
+            = f.fields_for :images do |b|
+              .image-upload-box
+                = b.file_field :image, class: "image-upload-btn", accept: "image/*"
+                %pre.image-upload-label
+                  ドラッグアンドドロップ
+                  またはクリックしてファイルをアップロード
+      = render partial: 'items/form', locals: { f: f }
+      -# form 出品ボタン
+      .exhibit-form
+        .exhibit-form__btn1
+          = f.submit "変更する", class: "exhibit-form-send-btn"
+        .exhibit-form__btn2
+          %a{href: "javascript:history.back()", class: "exhibit-return-btn"} キャンセル
+
+  -# ③フッター
+  = render 'items/layouts/exhibit_footer'

--- a/app/views/items/layouts/_exhibit_footer.html.haml
+++ b/app/views/items/layouts/_exhibit_footer.html.haml
@@ -1,0 +1,6 @@
+.exhibit-wrapper__footer
+  .exhibit-wrapper__footer__box
+    .exhibit-wrapper__footer__box__logo
+      =link_to image_tag("#{asset_path('logo_wjite_square.svg')}", size: "80x80", alt: "saicoro_logo_red"), root_path
+    .exhibit-wrapper__footer__box__name
+      Saicoro, Inc

--- a/app/views/items/layouts/_exhibit_header.html.haml
+++ b/app/views/items/layouts/_exhibit_header.html.haml
@@ -1,0 +1,3 @@
+.exhibit-wrapper__header
+  .exhibit-wrapper__header__logo
+    =link_to image_tag("#{asset_path('saicoro_logo_red.svg')}", size: "180x125", alt: "saicoro_logo_red"), root_path

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -3,9 +3,7 @@
 .exhibit-wrapper
 
   -# ①ヘッダー
-  .exhibit-wrapper__header
-    .exhibit-wrapper__header__logo
-      =link_to image_tag("#{asset_path('saicoro_logo_red.svg')}", size: "180x125", alt: "saicoro_logo_red"), root_path
+  = render 'items/layouts/exhibit_header'
 
   -# ②コンテンツ（formがメインになっている）
   .exhibit-wrapper__contents
@@ -28,35 +26,7 @@
                 %pre.image-upload-label
                   ドラッグアンドドロップ
                   またはクリックしてファイルをアップロード
-      -# form 商品名、商品説明
-      .exhibit-form
-        .exhibit-form__group
-          .exhibit-form__group__label
-            %label{ class: "exhibit-form-label" } 商品名
-            %span{ class: "exhibit-form-require"} 必須
-          .exhibit-form__group__input
-            = f.text_field :name, placeholder: "商品名（必須 40文字まで）", class: "textfield-default"
-        .exhibit-form__group--2
-          .exhibit-form__group__label
-            %label{ class: "exhibit-form-label" } 商品の説明
-            %span{ class: "exhibit-form-require"} 必須
-          .exhibit-form__group__input
-            = f.text_area :description, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class: "textarea-default"
-      -# form 販売価格
-      .exhibit-form
-        .exhibit-form__group2
-          .exhibit-form__group2__left
-            %label{ class: "exhibit-form-label-gray" } 販売価格
-            %label{ class: "exhibit-form-label-gray-small" } (300~9,999,999)
-          .exhibit-form__group2__right
-            .exhibit-form__group2__right__box#exhibit-form-price
-              .exhibit-form__group2__right__box__left
-                .exhibit-form__group2__right__box__left__box
-                  %label{ class: "exhibit-form-label" } 価格
-                  %span{ class: "exhibit-form-require"} 必須
-              .exhibit-form__group2__right__box__right
-                %label{ class: "exhibit-form-label-small" } ¥
-                = f.text_field :price, placeholder: "例）300", class: "textfield-small"
+      = render partial: 'items/form', locals: { f: f }
       -# form 出品ボタン
       .exhibit-form
         .exhibit-form__btn1
@@ -65,9 +35,4 @@
           %a{href: "javascript:history.back()", class: "exhibit-return-btn"} もどる
 
   -# ③フッター
-  .exhibit-wrapper__footer
-    .exhibit-wrapper__footer__box
-      .exhibit-wrapper__footer__box__logo
-        =link_to image_tag("#{asset_path('logo_wjite_square.svg')}", size: "80x80", alt: "saicoro_logo_red"), root_path
-      .exhibit-wrapper__footer__box__name
-        Saicoro, Inc
+  = render 'items/layouts/exhibit_footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -69,7 +69,7 @@
 
         -# ボタン3つ
         .details-wrapper__contents__btn
-          = link_to root_path, class: "btn-red" do
+          = link_to edit_item_path, class: "btn-red" do
             商品の編集
           .details-wrapper__contents__btn__or
             or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root "home#index"
   resources :sitemap, only: [:index]
   resources :mypages, only: [:index]
-  resources :items, only: [:new, :create, :show]
+  resources :items, only: [:new, :create, :show, :edit, :update]
   resources :profiles,only: [:new,:edit,:index]
   resources :items, only: [:new, :create, :show, :index]
   resources :credit_cards,only: [:index,:new,:create]


### PR DESCRIPTION
## What
### 商品情報編集の実装
#### サーバーサイド
- コントローラーの編集
#### フロント
- 部分テンプレートの作成
  - newとeditが見た目ほぼ同じなので共通部分をテンプレート化
    - headerとfooterを部分テンプレート化
    - formの共通箇所を部分テンプレート化

## Why
### 機能に関して
ユーザーが出品した後でも商品を編集できるようにする
### 部分テンプレートに関して
共通箇所を部分テンプレート化することで保守性を高めつつ、バグの発生率を抑える

## 問題
下記はまだ完成していないが、変更箇所が増えそうなので次のブランチで実装
- updateアクションの実装
- editアクションで画像の取得
  - editのビューも画像だけ変な感じになっている

## 動画
https://gyazo.com/5d065bd216461a85aafa4f12d3d65dc1