### PR TITLE
出品一覧画面修正

### DIFF
--- a/app/views/home/_content_wrapper.html.haml
+++ b/app/views/home/_content_wrapper.html.haml
@@ -5,4 +5,4 @@
         .item-list__heading
           %h3 アイテム一覧
         %ul.item-list__box
-          = render partial: 'layouts/item_list', collection: @item, as: 'item'
+          = render partial: 'layouts/item_list', collection: @items, as: 'item'


### PR DESCRIPTION
[what]出品一覧画面の修正
[why]一覧画像が表示されていなかったため
*メンターさんからの指摘で変数@itemを変数@Itemsに変更しましたが、viewフアイルに@itemのままで記述していたため、商品一覧が表示されないエラーが起きていました。訂正して表示されるようになりました
![FireShot Capture 010 - FreemarketSample59b - localhost](https://user-images.githubusercontent.com/54826284/73259658-992a9680-420b-11ea-9e00-cac24c662bed.png)

