### PR TITLE
デプロイ済みの崩れ修正（マイページの画像、フッター）

### DIFF
--- a/app/assets/stylesheets/profiles/_index.scss
+++ b/app/assets/stylesheets/profiles/_index.scss
@@ -1,6 +1,5 @@
 .profile-wrapper{
   width: 100vw;
-  // height: 100vh;
   background-color: $back-gray;
   
   &__contents {
@@ -29,7 +28,8 @@
 
       .profile-form{
         &__icon{
-          background-image: image-url("colorful_banner.png");          background-size: contain;
+          background-image: image-url("colorful_banner.png");
+          background-size: contain;
           background-position: center;
           padding: 72px 16px 24px;
 

--- a/app/assets/stylesheets/profiles/_index.scss
+++ b/app/assets/stylesheets/profiles/_index.scss
@@ -1,6 +1,6 @@
 .profile-wrapper{
   width: 100vw;
-  height: 100vh;
+  // height: 100vh;
   background-color: $back-gray;
   
   &__contents {
@@ -29,8 +29,7 @@
 
       .profile-form{
         &__icon{
-          background-image: url(colorful_banner.png);  
-          background-size: contain;
+          background-image: image-url("colorful_banner.png");          background-size: contain;
           background-position: center;
           padding: 72px 16px 24px;
 

--- a/app/views/profiles/index.html.haml
+++ b/app/views/profiles/index.html.haml
@@ -1,25 +1,28 @@
 -# 2-1.ユーザープロフィール編集ページ
 -# ①ヘッダー、②コンテンツ（②-1左カラム、②-2右カラム）、③フッターの大きく4要素でできている。
-.profile-wrapper
+.wrapper
   -# ①ヘッダー
   = render 'layouts/header'
   = render 'layouts/exhibit_btn'
-  -# ②コンテンツ
-  .profile-wrapper__contents
-    -# ②-1左カラム（キッドさん作成中）
-    = render 'mypages/left'
-    -# ②-2右カラム
-    .profile-wrapper__contents__right
-      %h2{ class: "profile-heading" } プロフィール
-      = form_with(local: true) do |f|
-        .profile-form
-          .profile-form__icon
-            .profile-form__icon__nickname
-              = f.text_field :nickname, placeholder: "例)PIRORI", class: "nickname-default"
-          .profile-form__content
-            .profile-form__content__text
-              = f.text_area :introduction, placeholder: "よろしくです", class: "introduction-default"
-            .profile-form__content__btn
-              = f.submit "変更する", class: "profile-form-send-btn"
--# ③フッター
-= render 'layouts/footer'
+  .content_wrapper
+    .profile-wrapper
+      -# ②コンテンツ
+      .profile-wrapper__contents
+        -# ②-1左カラム（キッドさん作成中）
+        = render 'mypages/left'
+        -# ②-2右カラム
+        .profile-wrapper__contents__right
+          %h2{ class: "profile-heading" } プロフィール
+          = form_with(local: true) do |f|
+            .profile-form
+              .profile-form__icon
+                -# =link_to image_tag("#{asset_path('colorful_banner.png')}", size: "580x200")
+                .profile-form__icon__nickname
+                  = f.text_field :nickname, placeholder: "例)PIRORI", class: "nickname-default"
+              .profile-form__content
+                .profile-form__content__text
+                  = f.text_area :introduction, placeholder: "よろしくです", class: "introduction-default"
+                .profile-form__content__btn
+                  = f.submit "変更する", class: "profile-form-send-btn"
+  -# ③フッター
+  = render 'layouts/footer'

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -1,51 +1,52 @@
 -# 2-2.ユーザー本人確認ページ
 -# ①ヘッダー、②コンテンツ（②-1左カラム、②-2右カラム）、③フッターの大きく4要素でできている。
-.profile-wrapper
+.wrapper
   -# ①ヘッダー
   = render 'layouts/header'
   = render 'layouts/exhibit_btn'
-  -# ②コンテンツ
-  .profile-wrapper__contents
-    -# ②-1左カラム（キッドさん作成中）
-    = render 'mypages/left'
-    -# ②-2右カラム
-    .profile-wrapper__contents__right
-      %h2.profile-heading 本人情報の登録
-      = form_with(class: "profile-form",local: true) do |f|
-        %div
-          %p お客さまの本人情報をご登録ください。登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
-        .profile__group
-          %label お名前
-          %p 渡辺ひろこ
-        .profile__group
-          %label お名前カナ
-          %p ワタナベヒロコ
-        .profile__group
-          %label 生年月日
-          %p 2000/01/01 
-        .profile__group
-          %label 郵便番号
-          %span.form-optional 任意 
-          = f.text_field :zip_code, placeholder: "例)1234567", class: "textfield-default"
-        .profile__group
-          %label 都道府県
-          %span.form-optional 任意 
-          -# 後ほどselect式にしたい
-          = f.text_field :prefecture, placeholder: "例)東京都", class: "textfield-default"
-        .profile__group
-          %label 市区町村
-          %span.form-optional 任意 
-          = f.text_field :city, placeholder: "例)横浜市緑区", class: "textfield-default"
-        .profile__group
-          %label 番地
-          %span.form-optional 任意 
-          = f.text_field :address1_label, placeholder: "青山1-1-1", class: "textfield-default"
-        .profile__group
-          %label 建物名
-          %span.form-optional 任意 
-          = f.text_field :address2_label, placeholder: "オロロロビル101", class: "textfield-default"
-        .profile-form__btn
-          = f.submit "登録する", class: "profile-form-send-btn"
-
--# ③フッター かぶさる問題があるので一旦コメントアウト
--# = render 'layouts/footer'
+  .content_wrapper
+    .profile-wrapper
+      -# ②コンテンツ
+      .profile-wrapper__contents
+        -# ②-1左カラム（キッドさん作成中）
+        = render 'mypages/left'
+        -# ②-2右カラム
+        .profile-wrapper__contents__right
+          %h2.profile-heading 本人情報の登録
+          = form_with(class: "profile-form",local: true) do |f|
+            %div
+              %p お客さまの本人情報をご登録ください。登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            .profile__group
+              %label お名前
+              %p 渡辺ひろこ
+            .profile__group
+              %label お名前カナ
+              %p ワタナベヒロコ
+            .profile__group
+              %label 生年月日
+              %p 2000/01/01 
+            .profile__group
+              %label 郵便番号
+              %span.form-optional 任意 
+              = f.text_field :zip_code, placeholder: "例)1234567", class: "textfield-default"
+            .profile__group
+              %label 都道府県
+              %span.form-optional 任意 
+              -# 後ほどselect式にしたい
+              = f.text_field :prefecture, placeholder: "例)東京都", class: "textfield-default"
+            .profile__group
+              %label 市区町村
+              %span.form-optional 任意 
+              = f.text_field :city, placeholder: "例)横浜市緑区", class: "textfield-default"
+            .profile__group
+              %label 番地
+              %span.form-optional 任意 
+              = f.text_field :address1_label, placeholder: "青山1-1-1", class: "textfield-default"
+            .profile__group
+              %label 建物名
+              %span.form-optional 任意 
+              = f.text_field :address2_label, placeholder: "オロロロビル101", class: "textfield-default"
+            .profile-form__btn
+              = f.submit "登録する", class: "profile-form-send-btn"
+  -# ③フッター
+  = render 'layouts/footer'


### PR DESCRIPTION
## What
・マイページ＞プロフィールの画像の表示記述の変更
`background-image: url(colorful_banner.png);`
↓
`background-image: image-url("colorful_banner.png");`

・マイページ＞プロフィールのフッター崩れ修正
・マイページ＞本人情報のフッター崩れ修正

## Why
>・マイページ＞プロフィールの画像の表示記述の変更

デプロイ環境で画像が表示されないため。

>・マイページ＞プロフィールのフッター崩れ修正

>・マイページ＞本人情報のフッター崩れ修正

フッターの位置がずれているため

## 直した後のキャプチャ

<img width="1440" alt="スクリーンショット 2020-02-03 22 48 34" src="https://user-images.githubusercontent.com/30643581/73658421-a3e79e80-46d7-11ea-99ab-fde283dc44dc.png">
<img width="1440" alt="スクリーンショット 2020-02-03 22 48 41" src="https://user-images.githubusercontent.com/30643581/73658424-a4803500-46d7-11ea-9c6c-804c491993b1.png">
