### PR TITLE
本人情報登録ページのサーバー実装

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,6 +4,6 @@ class ProfilesController < ApplicationController
   end
 
   def new
-    # require 'date'
+  
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,9 @@
 class ProfilesController < ApplicationController
+  before_action :move_to_Log_in
   def index
   end
 
   def new
+    # require 'date'
   end
 end

--- a/app/views/profiles/new.html.haml
+++ b/app/views/profiles/new.html.haml
@@ -16,13 +16,16 @@
           %p お客さまの本人情報をご登録ください。登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
         .profile__group
           %label お名前
-          %p 渡辺ひろこ
+          %p
+            = current_user.name_sei + current_user.name_mei
         .profile__group
           %label お名前カナ
-          %p ワタナベヒロコ
+          %p
+            = current_user.kana_sei+current_user.kana_mei
         .profile__group
           %label 生年月日
-          %p 2000/01/01 
+          %p 
+            = current_user.birth_date.strftime("%Y年%-m月%-d日")
         .profile__group
           %label 郵便番号
           %span.form-optional 任意 


### PR DESCRIPTION
[what]・本人情報登録ページの名前、カナ、生年月日の項目にログインしているユーザーの情報だけ表示させる
　　　・ログインしていなければ、ログイン画面に遷移させる
ログアウト時
https://gyazo.com/5c3bf7bbd63ce1cd1163f3f7c24edec1



ログイン時
![FireShot Capture 011 - FreemarketSample59b - localhost](https://user-images.githubusercontent.com/54826284/73841419-ee932300-485d-11ea-88b1-1a29086d5781.png)
