### PR TITLE
ログアウト画面でログイン画面を表示させる

### DIFF
--- a/app/controllers/logout_controller.rb
+++ b/app/controllers/logout_controller.rb
@@ -1,4 +1,5 @@
 class LogoutController < ApplicationController
+  before_action :move_to_Log_in
   def index
   end
 end


### PR DESCRIPTION
[what] ログアウト画面において、ログインしていないのにログアウト画面が表示されてしまうため、ログインしていなければログイン画面に遷移させるようにした

https://gyazo.com/2113ac40c8a6cef7692f29c3335d52ab