### PR TITLE
自分が出品したアイテムは購入できないようにする

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_Log_in, except:[:show]
   before_action :set_item, only:[:purchase,:pay,:show]
+  before_action :check_not_myitem
 
   def index
   end
@@ -47,4 +48,12 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
+  def check_not_myitem # itemの出品者とログインユーザーが異なるか確認
+    @item = Item.find(params[:id])
+    if @item.user_id == current_user.id
+      redirect_to myitem_path
+    end
+  end
+
 end


### PR DESCRIPTION
## What
private以下に「itemの出品者とログインユーザーが異なるか」判断する
check_not_myitem メソッドを追加しました。

・TOPページから自分が出品した商品詳細ページに遷移しようとすると、 /myitems/:id にリダイレクトします。
・自分が出品した商品ページURL（/items/:id）、商品購入画面のURL（/items/:id/purchase）を直打ちしても、/myitems/:id にリダイレクトします。
・自分が出品した商品ページからはpayアクション、purchaseアクションが動かないようにしています。

## Why

自分が出品した商品は購入できないようにするため。

## 動画

[![Screenshot from Gyazo](https://gyazo.com/1d7f2dee6f90cec8f227afeba3b6d6da/raw)](https://gyazo.com/1d7f2dee6f90cec8f227afeba3b6d6da)