### PR TITLE
新規ユーザー登録、ウィザード形式のビューを修正

### DIFF
--- a/app/assets/javascripts/devise/password_check.js
+++ b/app/assets/javascripts/devise/password_check.js
@@ -1,0 +1,15 @@
+// チェックボックスを押すと、パスワードが表示されるようにする
+$(function() {
+  const password = document.getElementById('user_password'); // パスワードのinputタグを取得
+  const check = document.getElementById('password_check'); // チェックボックスのinputタグを取得
+
+  if(password != null & check != null) { // 目的のページを開いている時だけ作動させる
+    check.addEventListener('change', function() { // チェックボックスが押された時、イベント発火
+      if(check.checked) {
+        password.setAttribute('type', 'text'); // パスワードのtype属性をtextに変更
+      } else {
+        password.setAttribute('type', 'password'); // パスワードのtype属性をpasswordに変更
+      };
+    }, false);
+  };
+});

--- a/app/assets/stylesheets/signup/_input_user_info.scss
+++ b/app/assets/stylesheets/signup/_input_user_info.scss
@@ -12,6 +12,14 @@
     font-size: 13px;
     font-weight: 600;
   }
+  &-any{
+    background: $gray;
+    color: $white;
+    border-radius: 2px;
+    padding: 0.3em;
+    font-size: 13px;
+    font-weight: 600;
+  }
   &__contents {
     &__sign{  
       &__nextstage-send-btn{
@@ -46,7 +54,8 @@
             padding-bottom: 10px;
           }
           &__confirm{
-            margin-bottom: 30px;
+            margin-top: 10px;
+            margin-bottom: 15px;
           }
           &__view{
             margin-bottom: 30px;
@@ -63,7 +72,7 @@
         }
 
         &__name{
-          margin-bottom: 60px;
+          margin-bottom: 30px;
           &__heading{
             &__label{
               padding-bottom: 10px;
@@ -109,16 +118,19 @@
               position: absolute;
               top: 10px;
               left: 80px;
+              pointer-events: none;
             }
             & .birth_date_mm{
               position: absolute;
               top: 10px;
               left: 185px;
+              pointer-events: none;
             }
             & .birth_date_dd{
               position: absolute;
               top: 10px;
               left: 290px;
+              pointer-events: none;
             }
             & select {
               padding-left: 10px;

--- a/app/views/devise/registrations/_footer.html.haml
+++ b/app/views/devise/registrations/_footer.html.haml
@@ -1,0 +1,6 @@
+.users-wrapper__footer
+  .users-wrapper__footer__box
+    .users-wrapper__footer__box__logo
+      =link_to image_tag("#{asset_path('logo_wjite_square.svg')}", size: "80x80", alt: "saicoro_logo_red"), root_path
+    .users-wrapper__footer__box__name
+      Saicoro, Inc

--- a/app/views/devise/registrations/_header.html.haml
+++ b/app/views/devise/registrations/_header.html.haml
@@ -1,0 +1,3 @@
+.users-wrapper__header
+  .users-wrapper__header__logo
+    =link_to image_tag("#{asset_path('saicoro_logo_red.svg')}", size: "180x125", alt: "saicoro_logo_red"), root_path

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -1,1 +1,13 @@
-登録完了
+.users-wrapper
+  = render 'devise/registrations/header'
+  .users-wrapper__contents
+    %h2 会員登録完了
+    .users-wrapper__contents__sign
+      .users-wrapper__contents__sign__complete
+        ありがとうございます。
+        %br 会員登録が完了しました。
+      .users-wrapper__contents__sign__start
+        = link_to root_path do
+          .users-wrapper__contents__sign__start__btn
+            サイコロをはじめる
+  = render 'devise/registrations/footer'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,54 +1,89 @@
-.wrapper
-  = render 'layouts/header'
-  .content_wrapper
-    = link_to 'Facebookで登録', user_facebook_omniauth_authorize_path, method: :post
-    = link_to 'Googleで登録', user_google_oauth2_omniauth_authorize_path, method: :post
-    %h2 Sign up
-    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-      = render "devise/shared/error_messages", resource: resource
-      .field
-        = f.label :nickname
-        %br/
-        = f.text_field :nickname, autofocus: true, autocomplete: "nickname"
-      .field
-        = f.label :name_sei
-        %br/
-        = f.text_field :name_sei, autofocus: true, autocomplete: "name_sei"
-      .field
-        = f.label :name_mei
-        %br/
-        = f.text_field :name_mei, autofocus: true, autocomplete: "name_mei"
-      .field
-        = f.label :kana_sei
-        %br/
-        = f.text_field :kana_sei, autofocus: true, autocomplete: "kana_sei"
-      .field
-        = f.label :kana_mei
-        %br/
-        = f.text_field :kana_mei, autofocus: true, autocomplete: "kana_mei"
-      .field
-        = f.label :birth_date
-        %br/
-        = f.date_select :birth_date, use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
-      .field
-        = f.label :email
-        %br/
-        = f.email_field :email, autofocus: true, autocomplete: "email"
-      - if @sns_id.present? # SNS認証して新規登録する場合はパスワード入力欄を表示しない
-        = hidden_field_tag :sns_auth, true # パスワードの代わりに次の値を送るタグを生成 params[:sns_auth] true
-      - else
-        .field
-          = f.label :password
-          - if @minimum_password_length
-            %em
-              (#{@minimum_password_length} characters minimum)
-          %br/
-          = f.password_field :password, autocomplete: "new-password"
-        .field
-          = f.label :password_confirmation
-          %br/
-          = f.password_field :password_confirmation, autocomplete: "new-password"
-      .actions
-        = f.submit "Next"
-    = render "devise/shared/links"
-    = render 'layouts/footer'
+.users-wrapper
+  = render 'devise/registrations/header'
+
+  .users-wrapper__contents
+    %h2 会員情報入力
+    .users-wrapper__contents__sign
+      .users-wrapper__contents__sign__signup
+        = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+          = render "devise/shared/error_messages", resource: resource
+          .users-wrapper__contents__sign__signup__nickname
+            .users-wrapper__contents__sign__signup__nickname__label
+              %label.users-wrapper-label ニックネーム
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__nickname__input
+              = f.text_field :nickname, placeholder: "例（メルカリ太郎）", class: "textfield-default"
+          .users-wrapper__contents__sign__signup__mail
+            .users-wrapper__contents__sign__signup__mail__label
+              %label.users-wrapper-label メールアドレス
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__mail__input
+              = f.text_field :email, placeholder: "PC,携帯どちらでも可", class: "textfield-default"
+
+          - if @sns_id.present? # SNS認証して新規登録する場合はパスワード入力欄を表示しない
+            = hidden_field_tag :sns_auth, true # パスワードの代わりに次の値を送るタグを生成 params[:sns_auth] true
+          - else
+            .users-wrapper__contents__sign__signup__password
+              .users-wrapper__contents__sign__signup__password__label
+                %label.users-wrapper-label パスワード
+                %span.users-wrapper-require 必須
+              .users-wrapper__contents__sign__signup__password__input
+                = f.password_field :password, placeholder: "７文字以上の半角英数字", class: "textfield-default"
+            .users-wrapper__contents__sign__signup__password__confirm ※ 英字と数字の両方を含めて設定してください
+            .users-wrapper__contents__sign__signup__password__view
+              =check_box_tag :password_check
+              =label_tag :check1, "パスワードを表示する"
+
+          .users-wrapper__contents__sign__signup__nameconfirm
+            .users-wrapper__contents__sign__signup__nameconfirm__label
+              %label.users-wrapper-label 本人確認
+            .users-wrapper__contents__sign__signup__nameconfirm__text
+              安心・安全にご利用いただくために、お客さまの本人
+              情報の登録にご協力ください。他のお客さまに公開されることはありません。
+          .users-wrapper__contents__sign__signup__name
+            .users-wrapper__contents__sign__signup__name__heading
+              .users-wrapper__contents__sign__signup__name__heading__label
+                %label.users-wrapper-label お名前（全角）
+                %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__name__textfield
+              .users-wrapper__contents__sign__signup__name__textfield__left
+              .users-wrapper__contents__sign__signup__name__textfield__left__input
+                = f.text_field :name_sei, placeholder: "例 山田", class: "textfield-default"
+              .users-wrapper__contents__sign__signup__name__textfield__right  
+              .users-wrapper__contents__sign__signup__name__textfield__right__input
+                = f.text_field :name_mei, placeholder: "例 花子", class: "textfield-default"
+          .users-wrapper__contents__sign__signup__nameconfirm
+            .users-wrapper__contents__sign__signup__nameconfirm__heading
+              .users-wrapper__contents__sign__signup__nameconfirm__heading__label
+                %label.users-wrapper-label お名前カナ（全角）
+                %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__nameconfirm__textfield
+              .users-wrapper__contents__sign__signup__nameconfirm__textfield__left
+              .users-wrapper__contents__sign__signup__nameconfirm__textfield__left__input
+                = f.text_field :kana_sei, placeholder: "例 ヤマダ", class: "textfield-default"
+              .users-wrapper__contents__sign__signup__nameconfirm__textfield__right
+              .users-wrapper__contents__sign__signup__nameconfirm__textfield__right__input
+                = f.text_field :kana_mei, placeholder: "例 アヤ", class: "textfield-default"
+          .users-wrapper__contents__sign__signup__born
+            .users-wrapper__contents__sign__signup__born__heading
+              .users-wrapper__contents__sign__signup__born__heading__label
+                %label.users-wrapper-label 生年月日
+                %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__born__textfield
+              .users-wrapper__contents__sign__signup__born__textfield__input
+                = f.date_select :birth_date, use_month_numbers: true, start_year: 1900, end_year: (Time.now.year), default: Date.new(Time.now.year, 1, 1)
+                .birth_date_yyyy
+                  = fa_icon("chevron-down")
+                .birth_date_mm
+                  = fa_icon("chevron-down") 
+                .birth_date_dd
+                  = fa_icon("chevron-down") 
+          .users-wrapper__contents__sign__signup__certificate
+            ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+          .users-wrapper__contents__sign__signup__userpolicy
+            「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします
+          .users-wrapper__contents__sign__nextstage
+            .users-wrapper__contents__sign__nextstage__btn
+              = f.submit "次へ進む", class: "users-wrapper__contents__sign__nextstage-send-btn"
+
+  = render 'devise/registrations/footer'

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,50 +1,66 @@
-.wrapper
-  = render 'layouts/header'
-  .content_wrapper
-    %h2 住所登録
-    = form_for @address do |f|
-      = render "devise/shared/error_messages", resource: @address
-      .field
-        = f.label :name_sei
-        %br/
-        = f.text_field :name_sei, autofocus: true, autocomplete: "name_sei"
-      .field
-        = f.label :name_mei
-        %br/
-        = f.text_field :name_mei, autofocus: true, autocomplete: "name_mei"
-      .field
-        = f.label :kana_sei
-        %br/
-        = f.text_field :kana_sei, autofocus: true, autocomplete: "kana_sei"
-      .field
-        = f.label :kana_mei
-        %br/
-        = f.text_field :kana_mei, autofocus: true, autocomplete: "kana_mei"
-      .field
-        = f.label :postal_code
-        %br/
-        = f.text_field :postal_code, autofocus: true, autocomplete: "postal_code"
-      .field
-        = f.label :prefectures
-        %br/
-        = f.text_field :prefectures, autofocus: true, autocomplete: "prefectures"
-      .field
-        = f.label :city
-        %br/
-        = f.text_field :city, autofocus: true, autocomplete: "city"
-      .field
-        = f.label :address
-        %br/
-        = f.text_field :address, autofocus: true, autocomplete: "address"
-      .field
-        = f.label :building
-        %br/
-        = f.text_field :building, autofocus: true, autocomplete: "building"
-      .field
-        = f.label :tel
-        %br/
-        = f.text_field :tel, autofocus: true, autocomplete: "tel"
-      .actions
-        = f.submit "Sign up"
-    = render "devise/shared/links"
-    = render 'layouts/footer'
+.users-wrapper
+  = render 'devise/registrations/header'
+
+  .users-wrapper__contents
+    %h2 住所入力
+    .users-wrapper__contents__sign
+      .users-wrapper__contents__sign__signup
+        = form_for @address do |f|
+          = render "devise/shared/error_messages", resource: @address
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label お名前
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :name_sei, placeholder: "例) 山田 ", class: "textfield-default"
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :name_mei, placeholder: "例) 太郎 ", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label お名前カナ
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :kana_sei, placeholder: "例) ヤマダ ", class: "textfield-default"
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :kana_mei, placeholder: "例) アヤ ", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label 郵便番号
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :postal_code, placeholder: "例) 123-4567", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label 都道府県
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :prefectures, placeholder: "例) 北海道", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label 市区町村
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :city, placeholder: "例) 横浜市緑区", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label 番地
+              %span.users-wrapper-require 必須
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :address, placeholder: "例) 青山１−１−１", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label 番地
+              %span.users-wrapper-any 任意
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :building, placeholder: "例) 柳ビル１０３", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__label
+              %label.users-wrapper-label 電話
+              %span.users-wrapper-any 任意
+            .users-wrapper__contents__sign__signup__input
+              = f.text_field :tel, placeholder: "例) 09058674356", class: "textfield-default"
+          .users-wrapper__contents__sign__signup
+            .users-wrapper__contents__sign__signup__btn
+              = f.submit "登録する", class: "users-wrapper__contents__sign__signup__next-send-btn"
+
+  = render 'devise/registrations/footer'


### PR DESCRIPTION
## What
- 新規登録のビューがdeviseのデフォルト状態だったので修正
- すでにビューが作られていたので基本は移植しただけ
- パスワードを表示するチェックボックスを有効にするためjsも追加している

## Why
- ビューがデフォルト状態だったので改善

![localhost_3000_users_sign_up (1)](https://user-images.githubusercontent.com/56496677/75105352-464ece00-5655-11ea-9cbb-1d5aff5e9a5f.png)

![localhost_3000_users](https://user-images.githubusercontent.com/56496677/75105344-33d49480-5655-11ea-8b30-8a7503a1d0f9.png)

![localhost_3000_addresses (1)](https://user-images.githubusercontent.com/56496677/75105357-5797da80-5655-11ea-8dab-2359f8997169.png)
