### PR TITLE
商品詳細ページにまつわる2つの改善

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :move_to_Log_in, except:[:show]
   before_action :set_item, only:[:purchase,:pay,:show]
-  before_action :check_not_myitem, only:[:purchase,:pay,:show]
+  before_action :check_not_myitem, only:[:purchase,:pay]
   before_action :check_for_sale, only:[:purchase,:pay]
 
   def index

--- a/app/views/sell/create.html.haml
+++ b/app/views/sell/create.html.haml
@@ -10,5 +10,5 @@
         = link_to new_sell_path, class: "continue-exhibit-btn" do
           続けて出品する
       .exhibit-complete-wrapper__contents__box__link
-        = link_to root_path, class: "root-path-btn" do
+        = link_to item_path(@item.id), class: "root-path-btn" do
           商品ページへ行ってシェアする


### PR DESCRIPTION
## what
①出品完了ページのリンク先を商品詳細ページにした。
②ログインしていない人でもitem詳細が見れるようにした。

## why
①出品完了ページのリンク先がTOPページに飛んでいたため、違和感があった。出品した商品詳細ページに飛ばすようにした。
②check_not_myitem に showをいれていたことで、ログインしていない人がitem詳細ページを見れなくなっていたため改善した。
