### PR TITLE
mypageの修正

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,6 +1,9 @@
 class MypagesController < ApplicationController
   before_action :move_to_Log_in
   def index
-    @items =Item.where(user_id: current_user.id).includes(:images).order(id: "DESC").page(params[:page]).per(5)
+  end
+
+  def show
+    @items =Item.for_sale.where(user_id: current_user.id).includes(:images).order(id: "DESC").page(params[:page]).per(10)
   end
 end

--- a/app/views/mypages/_left.html.haml
+++ b/app/views/mypages/_left.html.haml
@@ -10,7 +10,7 @@
           出品する
           %i.fa.fa-chevron-right
       %li 
-        = link_to "#" do
+        = link_to mypage_path(current_user.id) do
           出品した商品ー出品中
           %i.fa.fa-chevron-right
       %li 

--- a/app/views/mypages/_right-myitem.html.haml
+++ b/app/views/mypages/_right-myitem.html.haml
@@ -1,0 +1,41 @@
+.main-container__right
+  %section.main-container__right__user-icon 
+    = link_to "#" do
+      %figure
+        = image_tag "#{asset_path('no_image.png')}",size:"60×60",alt:"トップ画"
+      %h2.bold
+        - if current_user.profile
+          = current_user.profile.nickname
+        - else
+          = link_to profiles_path do
+            .fa-edit.fa プロフィールを登録する  
+      .number
+        %div
+          評価
+          %span.bold 0
+        %div
+          出品数
+          %span.bold 0
+
+  %section.main-container__right__notification-todo
+    %ul.main-container__right__notification-todo__tab
+      %li.active
+        %h3
+          = link_to  do
+            出品中
+            %span.mypage-nav-number.hidden-large
+    .tab-content
+      %ul.ul-tab
+        - @items.each do |i|
+          %li
+            = link_to myitem_path(i.id) do
+              %figure
+                = image_tag(i.images[0].image.url, size: "45x45", alt: i.name)
+              .mypage-item-body
+                .mypage-item-text
+                  = i.name
+                %time
+                  %i.fa.fa-clock-o
+                    = i.created_at.strftime("%-m月%-d日")
+              %i.fa.fa-chevron-right
+      = paginate(@items)

--- a/app/views/mypages/_right.html.haml
+++ b/app/views/mypages/_right.html.haml
@@ -31,20 +31,6 @@
             やることリスト
     .tab-content
       %ul.ul-tab
-        - @items.each do |i|
-          %li
-            = link_to item_path(i.id) do
-              %figure
-                = image_tag(i.images[0].image.url, size: "45x45", alt: i.name)
-              .mypage-item-body
-                .mypage-item-text
-                  = i.name+"を出品しました"
-                %time
-                  %i.fa.fa-clock-o
-                    = i.created_at.strftime("%-m月%-d日")
-              %i.fa.fa-chevron-right
-          -# = link_to  "一覧を見る"
-      = paginate(@items)
   %section.main-container__right__under
     %h2.buy-item-head 購入した商品
     %ul.mypage-tabs

--- a/app/views/mypages/show.html.haml
+++ b/app/views/mypages/show.html.haml
@@ -1,0 +1,15 @@
+.wrapper
+  = render 'layouts/header'
+  = render 'layouts/exhibit_btn'
+  .content_wrapper
+    %nav.white-bar
+      %ul.pan
+        %li
+          - breadcrumb :mypage
+          = breadcrumbs
+
+    %main.main-container 
+      = render 'mypages/left'
+      = render 'mypages/right-myitem'
+    .main-cotainer-margin
+  = render 'layouts/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ devise_for :users, controllers: { # カスタマイズしたdeviseのcontroller�
   end
   
   root "home#index"
-  resources :mypages, only: [:index]
+  resources :mypages, only: [:index, :show]
   resources :myitems, only: [:show, :edit, :update, :destroy]
   resources :sell, only: [:new, :create]
   resources :items, only: [:show] do


### PR DESCRIPTION
## What
- mypageに飛ぶといきなり自分の商品一覧が表示される問題を解決
  - mypageに行くとお知らせだけ表示
  - mypageの出品中の商品一覧ボタンを押すと自分の商品一覧が表示
- mypage商品のリンクをクリックすると商品詳細ではなく購入ページに飛ぶ問題を解決
- 出品中の商品だけ表示されるようにした（購入済みの商品は表示されない）

## Why
- mypageの表記と機能が一致していなかったので表記通り動くよう改善した

## 動画
- before
https://gyazo.com/1e05c429b4c9137396359f4ad4b4400b
- after
https://gyazo.com/58af5aa2975f7a40e519e04b13f8b31f